### PR TITLE
Add throughput to MCMC_SEQ log.

### DIFF
--- a/src/edu/rice/cs/bioinfo/programs/phylonet/algos/MCMCseq/core/MC3.java
+++ b/src/edu/rice/cs/bioinfo/programs/phylonet/algos/MCMCseq/core/MC3.java
@@ -33,6 +33,8 @@ public class MC3 {
     private double _logLikelihood;
     private double _logPrior;
 
+    private long _lastSampleTime;
+
     private int examed = 0;
 
     public MC3(MC3Core core,
@@ -49,6 +51,7 @@ public class MC3 {
         this._logLikelihood = _state.calculateLikelihood();
         this._logPrior = _state.calculatePrior();
         this._logPost = this._logLikelihood + this._logPrior;
+        this._lastSampleTime = System.currentTimeMillis();
     }
 
     /**
@@ -173,10 +176,13 @@ public class MC3 {
                 }
                 double essPost = _core.addPosteriorESS(_logPost);
                 double essPrior = _core.addPriorESS(_logPrior);
-                System.out.printf("%d;    %2.5f;    %2.5f;    %2.5f;   %2.5f;    %2.5f;    %d;\n",
+                long curTime = System.currentTimeMillis();
+                System.out.printf("%d;    %2.5f;    %2.5f;    %2.5f;   %2.5f;    %2.5f;    %d;     %2.5f sec/sample;\n",
                         iteration, _logPost, essPost,
                         _logLikelihood, _logPrior, essPrior,
-                        _state.numOfReticulation());
+                        _state.numOfReticulation(),
+                        (curTime - _lastSampleTime) / 1000.0);
+                _lastSampleTime = curTime;
                 System.out.println(Networks.getFullString(_state.getNetworkObject()));
                 _core.addSample(_state.toList());
                 List<Tuple<String,Double>> netSample = new ArrayList<>();

--- a/src/edu/rice/cs/bioinfo/programs/phylonet/algos/MCMCseq/core/MC3Core.java
+++ b/src/edu/rice/cs/bioinfo/programs/phylonet/algos/MCMCseq/core/MC3Core.java
@@ -87,7 +87,7 @@ public class MC3Core {
                 }
                 main.setPreBurnInParams();
                 System.out.println("----------------------- Logger: -----------------------");
-                System.out.println("Iteration;    Posterior;  ESS;    Likelihood;    Prior;  ESS;    #Reticulation");
+                System.out.println("Iteration;    Posterior;  ESS;    Likelihood;    Prior;  ESS;    #Reticulation;     Throughput;");
             }
             if(i > burnin) {
                 _sampling = true;


### PR DESCRIPTION
Example log:
```
Iteration;    Posterior;  ESS;    Likelihood;    Prior;  ESS;    #Reticulation;     Throughput;
1;    -241.72942;    0.00000;    -248.24475;   6.51533;    0.00000;    0;     0.20300 sec/sample;
[0.026813131734671182](Smik:0.12568490499460777,(((Scer:4.581798263141686E-5,Skud:4.581798263141686E-5):2.6271678195665886E-5,Spar:7.208966082708275E-5):2.3563241459009272E-5,Sbay:9.565290228609202E-5):0.1255892520923217);
2;    -193.36190;    0.00000;    -198.56921;   5.20731;    0.00000;    0;     7.37800 sec/sample;
[0.051627023372555626]((((Scer:0.01349320985010823,Spar:0.01349320985010823):0.0171019618409059,Sbay:0.03059517169101413):0.0038696549879110483,Skud:0.03446482667892518):0.1257215245090805,Smik:0.16018635118800567);
```